### PR TITLE
Fix heap-use-after-free error detected by AddressSanitizer

### DIFF
--- a/SharedPtr.hpp
+++ b/SharedPtr.hpp
@@ -60,18 +60,19 @@ struct _SpCounterImplFused final : _SpCounter {
           _M_mem(__mem),
           _M_deleter(std::move(__deleter)) {}
 
-    ~_SpCounterImplFused() noexcept override {
+    ~_SpCounterImplFused() noexcept {
         _M_deleter(_M_ptr);
-#if __cpp_aligned_new
-        ::operator delete(
-            _M_mem, std::align_val_t(
-                        std::max(alignof(_Tp), alignof(_SpCounterImplFused))));
-#else
-        ::operator delete(_M_mem);
-#endif
     }
 
-    void operator delete(void *) noexcept {}
+    void operator delete(void *__mem) noexcept {
+#if __cpp_aligned_new
+        ::operator delete(
+            __mem, std::align_val_t(
+                        std::max(alignof(_Tp), alignof(_SpCounterImplFused))));
+#else
+        ::operator delete(__mem);
+#endif
+    }
 };
 
 template <class _Tp>


### PR DESCRIPTION
When _M_decref executes delete this for a shared_ptr created by makeShared(), it will dynamically bind to ~_SpCounterImplFused(), in which the heap memory for control block is freed by operator delete. But ~_SpCounterImplFused() will then invoke ~_SpCounter(), which results in heap memory use after free. This PR will fix the error.